### PR TITLE
Bean暂不支持基本类型，添加一些用户属性

### DIFF
--- a/haiyan-common/src/main/java/haiyan/common/RecordBeanTranceferUtil.java
+++ b/haiyan-common/src/main/java/haiyan/common/RecordBeanTranceferUtil.java
@@ -21,7 +21,7 @@ public class RecordBeanTranceferUtil {
 			if(!method.isAnnotationPresent(GetMethod.class))
 				continue;
 			GetMethod getMethod = method.getAnnotation(GetMethod.class);
-			String key = getMethod.value();
+			String key = getMethod.value().toUpperCase();
 			Object value = null;
 			try {
 				value = method.invoke(obj);
@@ -39,8 +39,8 @@ public class RecordBeanTranceferUtil {
 		for(Method method : methods){
 			if(!method.isAnnotationPresent(SetMethod.class))
 				continue;
-			SetMethod getMethod = method.getAnnotation(SetMethod.class);
-			String key = getMethod.value();
+			SetMethod setMethod = method.getAnnotation(SetMethod.class);
+			String key = setMethod.value().toUpperCase();
 			Object value = record.get(key);
 			try {
 				method.invoke(obj,value);

--- a/haiyan-common/src/main/java/haiyan/common/intf/session/ISession.java
+++ b/haiyan-common/src/main/java/haiyan/common/intf/session/ISession.java
@@ -9,12 +9,10 @@ import java.io.Closeable;
  *
  */
 public interface ISession extends Closeable {
-
 	/**
 	 * 是否存活
 	 * 
 	 * @return
 	 */
-	boolean isAlive();
-	
+	Boolean isAlive();
 }

--- a/haiyan-common/src/main/java/haiyan/common/intf/session/IUser.java
+++ b/haiyan-common/src/main/java/haiyan/common/intf/session/IUser.java
@@ -30,5 +30,11 @@ public interface IUser extends IUserSession, Serializable {
 	void setProperty(String key, Object value);
 	void setProperties(Map<String, Object> properties);
 	Map<?, ?> getProperties();
+	void setSex(String sex);
+	String getSex();
+	void setEmail(String email);
+	String getEmail();
+	void setMobile(String mobile);
+	String getMobile();
 }
  

--- a/haiyan-common/src/main/java/haiyan/common/intf/session/IUserSession.java
+++ b/haiyan-common/src/main/java/haiyan/common/intf/session/IUserSession.java
@@ -7,5 +7,5 @@ package haiyan.common.intf.session;
  *
  */
 public interface IUserSession extends ISession {
-	public void setAlive(boolean b);
+	public void setAlive(Boolean b);
 }

--- a/haiyan-common/src/main/java/haiyan/common/session/AppContext.java
+++ b/haiyan-common/src/main/java/haiyan/common/session/AppContext.java
@@ -24,12 +24,12 @@ public class AppContext implements IAppContext {
 
 	public AppContext() { 
 	}
-	private boolean alive;
+	private Boolean alive;
 	@Override
-	public boolean isAlive() {
+	public Boolean isAlive() {
 		return alive;
 	}
-	public void setAlive(boolean alive) {
+	public void setAlive(Boolean alive) {
 		this.alive = alive;
 	}
 	private IContext parent;

--- a/haiyan-common/src/main/java/haiyan/common/session/User.java
+++ b/haiyan-common/src/main/java/haiyan/common/session/User.java
@@ -26,7 +26,12 @@ public class User implements IUser, Serializable { // Externalizable
 	private String deptID;
 	private String DSN;
 	private IRole[] roles;
-	private boolean alive;
+	private Boolean alive;
+	private String languageName;
+	private String sex;
+	private String email;
+	private String mobile;
+	//@Table("SYSOPERATOR")
 	public User() {
 	}
 	User(String ID, String code, String name) {
@@ -102,7 +107,6 @@ public class User implements IUser, Serializable { // Externalizable
 	public void setName(String name) {
 		this.name = name;
 	}
-	private String languageName;
 	@SetMethod("languageName")
 	@Override
 	public void setLanguageName(String languageName) {
@@ -113,33 +117,66 @@ public class User implements IUser, Serializable { // Externalizable
 	public String getLanguageName() {
 		return this.languageName;
 	}
+	@Override
 	public void setProperty(String key, Object value) {
 		this.properties.put(key, value);
 	}
-	
+	@Override
 	public Object getProperty(String key) {
 		return this.properties.get(key);
 	}
 	@SetMethod("properties")
+	@Override
 	public void setProperties(Map<String, Object> properties) {
 		this.properties = properties;
 	}
 	@GetMethod("properties")
+	@Override
 	public Map<?, ?> getProperties() {
 		return this.properties;
 	}
 	@GetMethod("alive")
 	@Override
-	public boolean isAlive() {
+	public Boolean isAlive() {
 		return alive;
 	}
 	@SetMethod("alive")
 	@Override
-	public void setAlive(boolean alive) {
+	public void setAlive(Boolean alive) {
 		this.alive = alive;
 	}
 	@Override
 	public void close() throws IOException {
+	}
+	@SetMethod("sex")
+	@Override
+	public void setSex(String sex) {
+		this.sex = sex;
+	}
+	@GetMethod("sex")
+	@Override
+	public String getSex() {
+		return this.sex;
+	}
+	@SetMethod("email")
+	@Override
+	public void setEmail(String email) {
+		this.email = email;
+	}
+	@GetMethod("email")
+	@Override
+	public String getEmail() {
+		return this.email;
+	}
+	@SetMethod("mobile")
+	@Override
+	public void setMobile(String mobile) {
+		this.mobile = mobile;
+	}
+	@GetMethod("mobile")
+	@Override
+	public String getMobile() {
+		return this.mobile;
 	}
 
 }

--- a/haiyan-orm/src/main/java/haiyan/orm/database/TableDBContext.java
+++ b/haiyan-orm/src/main/java/haiyan/orm/database/TableDBContext.java
@@ -39,7 +39,7 @@ public class TableDBContext extends AppContext implements ITableDBContext {
 		return UUID.randomUUID().toString();
 	}
 	@Override
-	public boolean isAlive() {
+	public Boolean isAlive() {
 		ITableDBManager dbm = this.getDBM();
 		if (dbm==null)
 			return false;

--- a/haiyan-orm/src/main/java/haiyan/orm/database/sql/SQLTableDBManager.java
+++ b/haiyan-orm/src/main/java/haiyan/orm/database/sql/SQLTableDBManager.java
@@ -140,7 +140,7 @@ public abstract class SQLTableDBManager implements ITableDBManager, ISQLDBManage
 		this.setAutoCommit(false); // 如果此时没有conn也可以作为后面创建conn的依据
 	}
 	@Override
-	public boolean isAlive() {
+	public Boolean isAlive() {
 		try {
 			return this.connection != null && !this.connection.isClosed();
 		}catch(Throwable e){

--- a/haiyan-web/src/main/java/haiyan/web/session/WebContext.java
+++ b/haiyan-web/src/main/java/haiyan/web/session/WebContext.java
@@ -57,7 +57,7 @@ public class WebContext extends AppContext implements IWebContext{
 		return o!=null;
 	}
 	@Override
-	public boolean isAlive() {
+	public Boolean isAlive() {
 		return req!=null && res!=null && !res.isCommitted();
 	}
 	@Override


### PR DESCRIPTION
实体Bean是用IDBRecord保存的，当其在和SessionBean进行转换时，用的是RecordBeanTransferUtil，造成SessionBean不支持基本类型属性
